### PR TITLE
Resolve paths in passed config file relative to containing directory of the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ There's an expectation that NodeJS and your container engine of choice is also p
 A quick test dev environment using config defaults can be spun off leveraging npx by running the following command;
 
 ```bash
-npx -y --package=wpnd@latest wpnd start
+npx --package=wpnd@latest wpnd start
 ```
 
 # Usage
@@ -26,7 +26,8 @@ by specifying a config file. Checkout the [playground](https://github.com/eokone
 # Config Files
 
 WPND currently supports a `wpnd.config.json` file. It is expected to be in the project working directory, 
-adjacent to the project src directory. An alternative path to the config file might could be provided with `--config <file>` option.
+adjacent to the project src directory. An alternative path to the config file might could be provided with `--config <file>` option,
+when this is done the resolution of the srcDir and distDir will be relative to the containing directory of the config file.
 
 ### Config Options
 

--- a/src/cli/commands/destroy/action/runner/destroy-docker-runner.js
+++ b/src/cli/commands/destroy/action/runner/destroy-docker-runner.js
@@ -11,10 +11,7 @@ const destroyDockerRunner = (parsedConfig) =>
       'compose',
       parsedConfig.name
         ? ['--project-name', parsedConfig.name]
-        : [
-            '--file',
-            path.join(process.cwd(), parsedConfig.distDir, 'stack.yml'),
-          ],
+        : ['--file', path.join(parsedConfig.distDir, 'stack.yml')],
       'down',
     ].flat(),
     {

--- a/src/cli/commands/destroy/action/runner/destroy-podman-runner.js
+++ b/src/cli/commands/destroy/action/runner/destroy-podman-runner.js
@@ -9,7 +9,7 @@ const destroyDockerRunner = (parsedConfig) =>
     'podman-compose',
     [
       parsedConfig.name ? ['--project-name', parsedConfig.name] : null,
-      ['--file', path.join(process.cwd(), parsedConfig.distDir, 'stack.yml')],
+      ['--file', path.join(parsedConfig.distDir, 'stack.yml')],
       'down',
     ].flat(),
     {

--- a/src/cli/commands/shell/action/runner/shell-docker-runner.js
+++ b/src/cli/commands/shell/action/runner/shell-docker-runner.js
@@ -11,10 +11,7 @@ const shellDockerRunner = (parsedConfig, serviceName) =>
       'compose',
       parsedConfig.name
         ? ['--project-name', parsedConfig.name]
-        : [
-            '--file',
-            path.join(process.cwd(), parsedConfig.distDir, 'stack.yml'),
-          ],
+        : ['--file', path.join(parsedConfig.distDir, 'stack.yml')],
       'exec',
       serviceName,
       ['bash'].concat(

--- a/src/cli/commands/shell/action/runner/shell-podman-runner.js
+++ b/src/cli/commands/shell/action/runner/shell-podman-runner.js
@@ -9,7 +9,7 @@ const shellDockerRunner = (parsedConfig, service) =>
     'podman-compose',
     [
       parsedConfig.name ? ['--project-name', parsedConfig.name] : null,
-      ['--file', path.join(process.cwd(), parsedConfig.distDir, 'stack.yml')],
+      ['--file', path.join(parsedConfig.distDir, 'stack.yml')],
       'exec',
       service,
       ['bash'].concat(

--- a/src/cli/commands/start/action/runner/start-docker-runner.js
+++ b/src/cli/commands/start/action/runner/start-docker-runner.js
@@ -10,7 +10,7 @@ const startDockerRunner = ({ parsedConfig, detached, verbose }) =>
     [
       'compose',
       parsedConfig.name ? ['--project-name', parsedConfig.name] : null,
-      ['--file', path.join(process.cwd(), parsedConfig.distDir, 'stack.yml')],
+      ['--file', path.join(parsedConfig.distDir, 'stack.yml')],
       'up',
       [parsedConfig.environment.rebuildOnStart ? '--build' : null],
       [detached ? '--detach' : null],

--- a/src/cli/commands/start/action/runner/start-podman-compose-runner.js
+++ b/src/cli/commands/start/action/runner/start-podman-compose-runner.js
@@ -9,7 +9,7 @@ const startPodmanComposeRunner = ({ parsedConfig, detached, verbose }) =>
     'podman-compose',
     [
       parsedConfig.name ? ['--project-name', parsedConfig.name] : null,
-      ['--file', path.join(process.cwd(), parsedConfig.distDir, 'stack.yml')],
+      ['--file', path.join(parsedConfig.distDir, 'stack.yml')],
       'up',
       [parsedConfig.environment.rebuildOnStart ? '--build' : null],
       [detached ? '--detach' : '--abort-on-container-exit'],

--- a/src/cli/global-options/config/index.js
+++ b/src/cli/global-options/config/index.js
@@ -6,7 +6,7 @@ import merge from 'lodash.merge';
 import { validate } from 'schema-utils';
 import { Option, InvalidArgumentError } from 'commander';
 
-const require = createRequire(import.meta.url);
+const requireFn = createRequire(import.meta.url);
 
 const DEFAULT_CONFIG_FILE = 'wpnd.config.json';
 
@@ -43,16 +43,19 @@ export const resolveConfigValue = (configFilePath) => {
   try {
     fs.accessSync(configPath, FSConstants.R_OK);
 
-    const configSchema = require('./schema.json');
+    const configSchema = requireFn('./schema.json');
 
-    // eslint-disable-next-line import/no-dynamic-require
-    const parsedConfig = require(configPath);
+    const parsedConfig = requireFn(configPath);
 
     const mergedConfig = merge(defaultConfigOptions, parsedConfig);
 
     validate(configSchema, mergedConfig);
 
-    return mergedConfig;
+    return {
+      ...mergedConfig,
+      srcDir: path.join(path.dirname(configPath), mergedConfig.srcDir),
+      distDir: path.join(path.dirname(configPath), mergedConfig.distDir),
+    };
   } catch (e) {
     // in cases where no file was found but the provided values matches the default value,
     // ignore and return the default config values

--- a/src/cli/utils/generate-composer-config.js
+++ b/src/cli/utils/generate-composer-config.js
@@ -16,7 +16,7 @@ const generateComposerConfig = (parsedConfig) => {
   );
 
   return writeJsonFile(
-    path.join(process.cwd(), parsedConfig.distDir, 'composer.json'),
+    path.join(parsedConfig.distDir, 'composer.json'),
     {
       ...composerJsonTemplate,
       require: parsedConfig.wpackagist,

--- a/src/cli/utils/provision-container-definition.js
+++ b/src/cli/utils/provision-container-definition.js
@@ -9,7 +9,7 @@ const provisionContainerDefinition = async (distDir) => {
       path.dirname(url.fileURLToPath(import.meta.url)),
       '../../templates/core/*'
     ),
-    path.join(process.cwd(), distDir)
+    path.join(distDir)
   );
 };
 


### PR DESCRIPTION
This PR introduces changes so that when a config file is passed like so;

```bash
npx --package=wpnd@latest wpnd --config <path/to/some/configfile.json> start
```
The path for `srcDir` of the project and the `distDir` where the template files get copied to are resolved relatively to the containing directory of the config file.