### PR TITLE
feat: add init method to cli to only generate template files

### DIFF
--- a/module/src/cli/cli.js
+++ b/module/src/cli/cli.js
@@ -5,6 +5,7 @@ import { createRequire } from 'module';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
+import buildInitCommand from './commands/init/init.js';
 import buildStartCommand from './commands/start/start.js';
 import buildDestroyCommand from './commands/destroy/destroy.js';
 import buildShellCommand from './commands/shell/shell.js';
@@ -31,6 +32,7 @@ program
     const { config: configPath } = thisCommand.opts();
     thisCommand.setOptionValue('parsedConfig', resolveConfigValue(configPath));
   })
+  .addCommand(buildInitCommand())
   .addCommand(buildStartCommand())
   .addCommand(buildShellCommand())
   .addCommand(buildDestroyCommand())

--- a/module/src/cli/commands/init/init.js
+++ b/module/src/cli/commands/init/init.js
@@ -1,0 +1,23 @@
+import { Command } from 'commander';
+
+import provisionContainerDefinition from '../../utils/provision-container-definition.js';
+
+export async function initializationHandler() {
+  const { parsedConfig } = this.optsWithGlobals();
+
+  await provisionContainerDefinition(parsedConfig.distDir);
+}
+
+const buildInitCommand = () => {
+  const init = new Command('init');
+
+  init
+    .description(
+      'Initialize container definition for local wordpress dev environment'
+    )
+    .action(initializationHandler);
+
+  return init;
+};
+
+export default buildInitCommand;

--- a/module/src/cli/commands/init/init.test.js
+++ b/module/src/cli/commands/init/init.test.js
@@ -1,0 +1,10 @@
+import { expect, it, describe } from '@jest/globals';
+import { Command } from 'commander';
+
+import buildInitCommand from './init.js';
+
+describe('init command', () => {
+  it('returns an instance of Command', () => {
+    expect(buildInitCommand()).toBeInstanceOf(Command);
+  });
+});

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "wpnd": "yalc publish --changed --push ../module && yalc link wpnd && node_modules/.bin/wpnd",
+    "init": "yarn wpnd init",
     "start": "yarn wpnd start",
     "start:code": "yarn wpnd start --code",
     "destroy": "yarn wpnd destroy",


### PR DESCRIPTION
## Describe your changes

Add command to generate template files; 

```bash
npx --package=wpnd@latest wpnd init
```
<!--
## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
-->